### PR TITLE
Fix undefined behaviour delete

### DIFF
--- a/SubsystemTool/SubsystemTool.cpp
+++ b/SubsystemTool/SubsystemTool.cpp
@@ -192,8 +192,7 @@ int ProcessPath(_TCHAR* path, _TCHAR* subsys, BOOL ResetVersion)
 			return 5;
 		}
 		
-		delete fileBuf;
-
+		delete[] fileBuf;
 		CloseHandle(hFile);
 	}
 


### PR DESCRIPTION
Using `operator delete` on an `operator new[]` allocated memory is an undefined behaviour.

From cppreference.com:
"The behavior of the standard library implementation of this function is undefined unless ptr is a null pointer or is a pointer previously obtained from the standard library implementation of operator new(std::size_t) or operator new(std::size_t, std::nothrow_t)."

https://en.cppreference.com/w/cpp/memory/new/operator_delete
https://stackoverflow.com/a/2425749/5795772