### PR TITLE
Implement some functions needed for cmd.exe to work

### DIFF
--- a/COREDLL/Exports.def
+++ b/COREDLL/Exports.def
@@ -21,8 +21,8 @@ EXPORTS
 	FindNextFileW=FindNextFileW_WCECL @181
 	FindFirstFileW=FindFirstFileW_WCECL @167
 	WaitForAPIReady @2562
-	SetStdioPathW @1150
-	GetStdioPathW @1149
+	SetStdioPathW=SetStdioPathW_WCECL @1150
+	GetStdioPathW=GetStdioPathW_WCECL @1149
 	DeviceIoControl=DeviceIoControl_WCECL @179
 	_wfopen @1145
 	fread @1120
@@ -31,7 +31,7 @@ EXPORTS
 	_wcsupr @232
 	vfwprintf=vfwprintf_WCECL @721
 	fflush @1122
-	fgetws @1143
+	fgetws=fgetws_WCECL @1143
 	fputwc @1141
 	fputws @1144
 	_getstdfilex=_getstdfilex_WCECL @1100
@@ -133,7 +133,7 @@ EXPORTS
     towlower @194
     towupper @195
     MultiByteToWideChar @196
-    WideCharToMultiByte @197
+    WideCharToMultiByte=WideCharToMultiByte_WCECL @197
     CompareStringW @198
     LCMapStringW @199
     SetLocaleInfoW @201
@@ -398,7 +398,7 @@ EXPORTS
     qsort         @1052
     rand          @1053
     realloc       @1054
-    _fileno       @1124
+    _fileno=_fileno_WCECL       @1124
     feof          @1125
     ferror        @1126
     clearerr      @1127

--- a/COREDLL/other.cpp
+++ b/COREDLL/other.cpp
@@ -84,7 +84,7 @@ LCID WINAPI ConvertDefaultLocale_WCECL(LCID Locale)
 int _snwprintf_WCECL(wchar_t * buf, size_t bufCount, const wchar_t * fmt, ...)
 {
 #pragma warning( push )
-#pragma warning( disable: 4995 )
+#pragma warning( disable: 4995 4996)
 	va_list args;
 	va_start(args, fmt);
 

--- a/COREDLL/stdafx.h
+++ b/COREDLL/stdafx.h
@@ -40,6 +40,18 @@ typedef struct tagWNDCLASSW_WCECL {
 	LPCWSTR     lpszClassName;
 } WNDCLASSW_WCECL, *PWNDCLASSW_WCECL, *LPWNDCLASSW_WCECL;
 
+typedef struct tagWIN32_FIND_DATA_WCECL
+{
+	DWORD dwFileAttributes;
+	FILETIME ftCreationTime;
+	FILETIME ftLastAccessTime;
+	FILETIME ftLastWriteTime; 
+	DWORD nFileSizeHigh; 
+	DWORD nFileSizeLow; 
+	DWORD dwOID;
+	TCHAR cFileName[MAX_PATH];
+} WIN32_FIND_DATA_WCECL, *PWIN32_FIND_DATA_WCECL, *LPWIN32_FIND_DATA_WCECL;
+
 // MACROS
 #undef RasHangUp
 #undef RasDial

--- a/COREDLL/winbase_wcecl.cpp
+++ b/COREDLL/winbase_wcecl.cpp
@@ -367,20 +367,59 @@ BOOL WINAPI DeleteFileW_WCECL(LPCWSTR lpFileName)
 	auto result = DeleteFileW(lpFileName);
 	return result;
 }
+static void ConvertFindDataToWcecl(
+	LPWIN32_FIND_DATA_WCECL lpWceclData,
+	LPWIN32_FIND_DATAW lpFindData)
+{
+	wcscpy_s(lpWceclData->cFileName,
+		sizeof(lpWceclData->cFileName) / sizeof(*lpWceclData->cFileName),
+		lpFindData->cFileName);
+	lpWceclData->dwFileAttributes = lpFindData->dwFileAttributes;
+	lpWceclData->dwOID = lpFindData->dwReserved0;
+	lpWceclData->ftCreationTime = lpFindData->ftCreationTime;
+	lpWceclData->ftLastAccessTime = lpFindData->ftLastAccessTime;
+	lpWceclData->ftLastWriteTime = lpFindData->ftLastWriteTime;
+	lpWceclData->nFileSizeHigh = lpFindData->nFileSizeHigh;
+	lpWceclData->nFileSizeLow = lpFindData->nFileSizeLow;
+}
+
+static void ConvertFindDataFromWcecl(
+	LPWIN32_FIND_DATAW lpFindData,
+	LPWIN32_FIND_DATA_WCECL lpWceclData)
+{
+	wcscpy_s(lpFindData->cFileName,
+		sizeof(lpFindData->cFileName) / sizeof(*lpFindData->cFileName),
+		lpWceclData->cFileName);
+	lpFindData->dwFileAttributes = lpWceclData->dwFileAttributes;
+	lpFindData->dwReserved0 = lpWceclData->dwOID;
+	lpFindData->ftCreationTime = lpWceclData->ftCreationTime;
+	lpFindData->ftLastAccessTime = lpWceclData->ftLastAccessTime;
+	lpFindData->ftLastWriteTime = lpWceclData->ftLastWriteTime;
+	lpFindData->nFileSizeHigh = lpWceclData->nFileSizeHigh;
+	lpFindData->nFileSizeLow = lpWceclData->nFileSizeLow;
+}
 
 HANDLE WINAPI FindFirstFileW_WCECL(
 	LPCWSTR lpFileName,
-	LPWIN32_FIND_DATAW lpFindFileData)
+	LPWIN32_FIND_DATA_WCECL lpFindFileData)
 {
-	auto result = FindFirstFileW(lpFileName, lpFindFileData);
+	WIN32_FIND_DATAW findData;
+
+	ConvertFindDataFromWcecl(&findData, lpFindFileData);
+	auto result = FindFirstFileW(lpFileName, &findData);
+	ConvertFindDataToWcecl(lpFindFileData, &findData);
 	return result;
 }
 
 BOOL WINAPI FindNextFileW_WCECL(
 	HANDLE hFindFile,
-	LPWIN32_FIND_DATAW lpFindFileData)
+	LPWIN32_FIND_DATA_WCECL lpFindFileData)
 {
-	auto result = FindNextFileW(hFindFile, lpFindFileData);
+	WIN32_FIND_DATAW findData;
+
+	ConvertFindDataFromWcecl(&findData, lpFindFileData);
+	auto result = FindNextFileW(hFindFile, &findData);
+	ConvertFindDataToWcecl(lpFindFileData, &findData);
 	return result;
 }
 


### PR DESCRIPTION
Proposed changes implement some functions necessary for `cmd.exe` to start, most notably `_getstdfilex`, `SetStdioPathW` (untested/WIP), `GetStdioPathW` (untested/WIP), `WideCharToMultiByte`, and change some existing functions (`_fileno`, `FindFirstFile`, `FindNextFile`).

These changes are not sufficient to start `cmd.exe`. [Here](https://github.com/TheNNX/wcecl/tree/cursed) is a branch with a quick and dirty hack to get it working, however, better solutions are necessary. Two main problems are:
- Arguments expected by WinCE applications are not passed to the entrypoint by Windows (see issue #25)
- `cmd.exe` seems to expect to have a console already allocated (it does some `DeviceIoControl` calls, which maybe allocate the console - I don't know).

The more serious issue of the two is the first one. I see two main ways to solve it:
- `SubsystemTool` could patch the PE to add a custom entry point (this is somewhat difficult, as the code section would have to expand)
- Some sort of self modifying code solution - COREDLL could locate the entrypoint like it does in the quick dirty hack, but instead of invoking it, it could stub it out to intercept it. In the intercepting function, COREDLL would repair the entrypoint, and call it with correct arguments. 