### PR TITLE
Remove unnecessary __stdcall defines

### DIFF
--- a/COREDLL/dllmain.cpp
+++ b/COREDLL/dllmain.cpp
@@ -1,7 +1,6 @@
 // dllmain.cpp : Defines the entry point for the DLL application.
 #include "stdafx.h"
 
-#undef __stdcall // DllMain should be __stdcall always
 BOOL __stdcall DllMain(HMODULE hModule,
 	DWORD  ul_reason_for_call,
 	LPVOID lpReserved

--- a/COREDLL/stdafx.h
+++ b/COREDLL/stdafx.h
@@ -56,18 +56,6 @@ typedef struct tagWIN32_FIND_DATA_WCECL
 #undef RasHangUp
 #undef RasDial
 
-// Windows CE uses __cdecl instead of __stdcall everywhere, including WINAPI macro
-// (defined in wce/windef.h)
-#ifdef __stdcall
-#undef __stdcall
-#endif
-#define __stdcall __cdecl
-
-#ifdef _stdcall
-#undef _stdcall
-#endif
-#define _stdcall _cdecl
-
 #ifdef WINAPI
 #undef WINAPI
 #endif


### PR DESCRIPTION
The proposed changes remove unnecessary `__stdcall` defines. The macro is not used anywhere, and defining `__stdcall` to `__cdecl` is quite confusing in my opinion - it's a bit like `#define true false`. Where necessary (not that it is really - the entire project is set to use `__cdecl` as the default calling convention), functions can simply use the redefined `WINAPI` define.