### PR TITLE
Fix COREDLL CreateProcessW

### DIFF
--- a/COREDLL/winbase_wcecl.cpp
+++ b/COREDLL/winbase_wcecl.cpp
@@ -171,9 +171,13 @@ BOOL WINAPI CreateProcessW_WCECL(
 	LPSTARTUPINFO psiStartInfo,
 	LPPROCESS_INFORMATION pProcInfo)
 {
+	std::wstring commandLine = std::wstring(pszImageName) + L" " + std::wstring(pszCmdLine);
+	wchar_t* commandLineCString = new wchar_t[commandLine.length() + 1];
+	wcscpy(commandLineCString, commandLine.c_str());
+
 	auto result = CreateProcessW(
 		pszImageName,
-		(LPWSTR)pszCmdLine,
+		commandLineCString,
 		psaProcess,
 		psaThread,
 		fInheritHandles,


### PR DESCRIPTION
Windows applications expect the the command file name to be present in `lpCommandLine` in `CreateProcessW`, WinCE programs seem to not (or at least `cmd.exe` doesn't). 