### PR TITLE
Fix cmd.exe ungraceful exit

### DIFF
--- a/COREDLL/winbase_wcecl.cpp
+++ b/COREDLL/winbase_wcecl.cpp
@@ -12,7 +12,7 @@ BOOL SystemTimeToFileTime_WCECL(
 
 BOOL FileTimeToLocalFileTime_WCECL(
 	const FILETIME* lpFileTime,
-	LPFILETIME     lpLocalFileTime)
+	LPFILETIME	 lpLocalFileTime)
 {
 	auto result = ::FileTimeToLocalFileTime(lpFileTime, lpLocalFileTime);
 	return result;
@@ -590,6 +590,11 @@ BOOL WINAPI TerminateProcess_WCECL(
 	HANDLE hProcess,
 	DWORD uExitCode)
 {
+	/* GetCurrentProcess() seems to be inlined to 0x42 for WinCE */
+	if (hProcess == (HANDLE)0x42)
+	{
+		hProcess = GetCurrentProcess();
+	}
 	auto result = ::TerminateProcess(hProcess, uExitCode);
 	return result;
 }


### PR DESCRIPTION
It seems that WinCE has `GetCurrentProcess` inlined to return 0x42. Because this is not the case with Win32, `TerminateProcess(0x42, ...)` fails, `cmd.exe` returns from a noreturn function, and executes some random code it should not execute, which causes it to crash.  

```c
int WINAPI WinMain(
    HINSTANCE hInstance,
    HINSTANCE hPrevInstance,
    LPTSTR lpCmdLine,
    int nCmdShow)
{
    HANDLE result = GetCurrentProcess();
    printf("%lx\n", (int)result);
    return (int)result;
}
```
gets compiled to:
```asm
_WinMain:
  000110C4: 6A 42              push        42h
  000110C6: 68 3C 10 01 00     push        offset ??_C@_04OBABDBEP@?$CFlx?6?$AA@
  000110CB: E8 32 02 00 00     call        _printf
  000110D0: 59                 pop         ecx
  000110D1: 59                 pop         ecx
  000110D2: 6A 42              push        42h
  000110D4: 58                 pop         eax
  000110D5: C3                 ret
  ```